### PR TITLE
Automatic rehydration within Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Unfortunately I didn't find a way to use this file for SSR and browser, because 
 ```javascript
 import React from 'react'
 import { Router } from 'react-router-dom'
-import { rehydrate } from 'fela-dom'
 import { Provider } from 'react-fela'
 import { createRenderer } from 'fela'
 
@@ -42,7 +41,7 @@ exports.wrapRootComponent = ({ Root }, pluginOptions) => {
     console.log(e)
   }
   const renderer = createRenderer(config)
-  rehydrate(renderer)
+
   const wrappedRootComponent = ({ children }) => (
     <Provider renderer={renderer}>
       <Root />


### PR DESCRIPTION
Just a quick note. The manual `rehydrate(renderer)` is not required as react-fela's `Provider` automatically rehydrates the styles. Otherwise, you'd end up doubling the cost.