### PR TITLE
Fix plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ Unfortunately I didn't find a way to use this file for SSR and browser, because 
 
 ```javascript
 import React from 'react'
-import { Router } from 'react-router-dom'
-import { Provider } from 'react-fela'
+import { RendererProvider } from 'react-fela'
 import { createRenderer } from 'fela'
-
 
 exports.wrapRootElement = ({ element }) => {
   let config;

--- a/README.md
+++ b/README.md
@@ -33,23 +33,22 @@ import { Router } from 'react-router-dom'
 import { Provider } from 'react-fela'
 import { createRenderer } from 'fela'
 
-exports.wrapRootComponent = ({ Root }, pluginOptions) => {
+
+exports.wrapRootElement = ({ element }) => {
   let config;
   try {
-    config = require(`./fela.config.js`)
+    config = require(`./fela.config.js`);
   } catch (e) {
-    console.log(e)
+    console.log(e);
   }
-  const renderer = createRenderer(config)
+  const renderer = createRenderer(config);
 
-  const wrappedRootComponent = ({ children }) => (
-    <Provider renderer={renderer}>
-      <Root />
-    </Provider>
-  )
-
-  return wrappedRootComponent
-}
+  return (
+    <RendererProvider renderer={renderer}>
+      {element}
+    </RendererProvider>
+  );
+};
 ```
 
 If you have an idea to solve this problem feel free to open a pull request.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ exports.wrapRootElement = ({ element }) => {
 
 If you have an idea to solve this problem feel free to open a pull request.
 
+### Importing fela plugins
+
+When you're importing fela plugins, don't forget your `fela.config.js` file is a commonjs file, but plugins are transpiled using babel from ES6 import/export syntax into format that uses `interopRequireDefault` function. So for correct import of the plugin, you have to import `.default` from the package as shown at the example below.
+
+```js
+const unit = require("fela-plugin-unit").default
+
+module.exports = {
+  plugins: [
+    unit(),
+  ],
+}
+```
+
 ## Example
 
 https://github.com/mmintel/example-gatsby-fela

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-fela": "^10.1.0"
   },
   "peerDependencies": {
-    "gatsby": "^1.0.0"
+    "gatsby": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-fela",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Gatsby plugin that adds support for fela.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi, I've tried to solve the problem with `gatsby-browser` but I wasn't successful yet. So at least I've fixed a description of how to solve the problem, because it wasn't valid for gatsby@2 and was the first thing I had to solve when tried to use you plugin first time.
Also I've added a brief description about importing fela plugins in the `fela.config.js` to help users save some time, I had to spend figuring out what's wrong on my first plugin usage 🙂 